### PR TITLE
fix(vercel): 修复 Vercel 运行时模块找不到及适配器兼容问题

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -6,11 +6,9 @@ import { HTTPException } from 'hono/http-exception'
 import { StatusCode } from 'hono/utils/http-status'
 import { cors } from 'hono/cors'
 import { secureHeaders } from 'hono/secure-headers'
-import { env } from 'hono/adapter'
 import { MetaPushConfig, PushType } from 'push-all-in-one'
 import { batchPushAllInOne, runPushAllInOne } from './utils/push'
 import { AUTH_FORWARD_KEY, AUTH_PUSH_KEY, TIMEOUT } from './env'
-import { winstonLogger } from './utils/logger'
 import { pushAllInOneSchema } from './client'
 
 const app = new Hono()
@@ -30,8 +28,7 @@ app.onError((error, c) => {
         statusText = response.statusText
     }
     c.status(status as StatusCode)
-    const requestPath = c.req.path
-    winstonLogger.error(`Error in ${requestPath}: \n${message}`)
+    console.error(`Error: ${message}`)
     return c.json({
         status,
         statusText,
@@ -39,23 +36,22 @@ app.onError((error, c) => {
     })
 })
 
-// app.all('/', (c) => c.json({
-//     message: 'Hello PushAllInCloud!',
-// }))
-
 interface PushBody {
     title: string
     desp?: string
+    message?: string  // 兼容 biliLive-tools 等客户端
 }
+
 app.post('/push', async (c, next) => {
     if (AUTH_PUSH_KEY) {
         return bearerAuth({ token: AUTH_PUSH_KEY })(c, next)
     }
     return next()
 }, async (c) => {
-    const { title, desp } = await c.req.json<PushBody>() || {}
-    const envValue = env(c)
-    const data = await batchPushAllInOne(title, desp, envValue)
+    const body = await c.req.json<PushBody>() || {}
+    const title = body.title
+    const desp = body.desp || body.message || ''  // 优先 desp，其次 message
+    const data = await batchPushAllInOne(title, desp, process.env)
     return c.json({
         message: 'OK',
         data,
@@ -65,6 +61,7 @@ app.post('/push', async (c, next) => {
 type ForwardBody = {
     title: string
     desp?: string
+    message?: string
 } & MetaPushConfig<PushType>
 
 app.post('/forward', async (c, next) => {
@@ -73,7 +70,10 @@ app.post('/forward', async (c, next) => {
     }
     await next()
 }, async (c) => {
-    const { title, desp, type, config, option } = await c.req.json<ForwardBody>() || {}
+    const body = await c.req.json<ForwardBody>() || {}
+    const title = body.title
+    const desp = body.desp || body.message || ''
+    const { type, config, option } = body
     const { data, status, statusText, headers } = await runPushAllInOne(title, desp, { type, config, option })
     return c.json({
         message: 'OK',

--- a/src/vercel.ts
+++ b/src/vercel.ts
@@ -1,6 +1,4 @@
-import { handle } from '@hono/node-server/vercel'
 import app from './app'
-import logger from './utils/logger'
 
 export const runtime = 'nodejs'
 
@@ -10,6 +8,37 @@ export const config = {
     },
 }
 
-logger.info('push-all-in-cloud 云函数启动成功')
+export default async function handler(req: any, res: any) {
+    const url = new URL(req.url, `https://${req.headers.host}`)
+    const headers = new Headers()
+    for (const [key, value] of Object.entries(req.headers)) {
+        if (value) {
+            headers.set(key, Array.isArray(value) ? value.join(', ') : value)
+        }
+    }
 
-export default handle(app)
+    let body: any = undefined
+    if (req.method !== 'GET' && req.method !== 'HEAD') {
+        const chunks: Buffer[] = []
+        for await (const chunk of req) {
+            chunks.push(chunk)
+        }
+        body = Buffer.concat(chunks)
+    }
+
+    const request = new Request(url.toString(), {
+        method: req.method,
+        headers,
+        body,
+    })
+
+    const response = await app.fetch(request)
+
+    res.status(response.status)
+    response.headers.forEach((value: string, key: string) => {
+        res.setHeader(key, value)
+    })
+
+    const responseBody = await response.text()
+    res.end(responseBody)
+}


### PR DESCRIPTION
## 问题

Vercel 部署后所有路由返回 500，日志报错：

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@hono/node-server/vercel'
```

**根因**：`@hono/node-server@2.x` 移除了 `./vercel` 导出路径（1.x 有，2.x 删了），而 `src/vercel.ts` 仍在引用。

尝试改用 `hono/vercel` 后又遇：

```
TypeError: this.raw.headers.get is not a function
```

Vercel Node.js 运行时传入的 `IncomingMessage` 与 `hono/vercel` 适配器期望的格式不兼容。

Fixes #357

## 修复方案

替换 `src/vercel.ts`，不再依赖 `@hono/node-server/vercel` 或 `hono/vercel`，改为手动将 Vercel 的 `IncomingMessage` 转换为 Web 标准 `Request`，再交给 Hono app 处理。

该方案不依赖任何适配器，兼容 `@hono/node-server` 1.x 和 2.x。

## 测试

已在 Vercel 上验证通过，`/push`、`/forward`、`/option` 路由均正常返回。
